### PR TITLE
Pick Block From Bundle Inventory

### DIFF
--- a/src/main/java/com/wolfyscript/bundleinv/BundleInv.java
+++ b/src/main/java/com/wolfyscript/bundleinv/BundleInv.java
@@ -69,20 +69,10 @@ public class BundleInv implements ModInitializer {
 
                 if (!hotbarItem.isEmpty()) {
                     // The hotbar item needs to be swapped. The hotbar and bundle item can have different load factors inside the bundle inventory, so they might not be able to swap!
+                    int bundleItemLoad = PlayerBundleStorage.getItemStackLoad(bundleStack);
+                    int hotbarItemLoad = PlayerBundleStorage.getItemStackLoad(hotbarItem);
 
-                    int bundleOccupancy = PlayerBundleStorage.getItemOccupancy(bundleStack);
-                    int hotbarOccupancy = PlayerBundleStorage.getItemOccupancy(hotbarItem);
-
-                    int toGetLoad = bundleOccupancy * bundleStack.getCount();
-                    int hotbarLoad = hotbarOccupancy * hotbarItem.getCount();
-                    int remainingCapacity = bundleStorage.getRemainingCapacity() - toGetLoad;
-
-                    if ( remainingCapacity < hotbarLoad ) {
-                        //TODO: There would be no space for the swapped items! what do?
-                        int remainingLoad = toGetLoad - hotbarLoad;
-                        int countLeft = remainingLoad / hotbarOccupancy;
-
-                    } else {
+                    if (bundleStorage.getRemainingCapacity() - bundleItemLoad >= hotbarItemLoad) {
                         inventory.selectedSlot = hotbarSlot;
                         bundleStorage.addStack(hotbarItem);
                         inventory.setStack(hotbarSlot, bundleStack);
@@ -90,6 +80,9 @@ public class BundleInv implements ModInitializer {
                         sendBundleStorageUpdate(player, false, bundleStack);
                         handler.sendPacket(new ScreenHandlerSlotUpdateS2CPacket(-2, 0, inventory.selectedSlot, inventory.getStack(inventory.selectedSlot)));
                         handler.sendPacket(new UpdateSelectedSlotS2CPacket(inventory.selectedSlot));
+                    } else {
+                        // There would be no space for the swapped items! what do?
+                        // For now, do nothing, maybe I find a solution later on.
                     }
                 } else {
                     // Move item from Bundle into the hotbar slot

--- a/src/main/java/com/wolfyscript/bundleinv/BundleInvConstants.java
+++ b/src/main/java/com/wolfyscript/bundleinv/BundleInvConstants.java
@@ -6,6 +6,7 @@ public class BundleInvConstants {
 
     public static final Identifier C2S_BUNDLE_ITEM_CONTAINER_CLICK_PACKET = new Identifier("bundleinv", "bundle_item_container_click");
     public static final Identifier C2S_BUNDLE_STORAGE_STORE_ITEM = new Identifier("bundleinv", "bundle_storage_store_item");
+    public static final Identifier C2S_PICK_FROM_BUNDLE_STORAGE = new Identifier("bundleinv", "pick_from_bundle_storage");
 
     public static final Identifier S2C_BUNDLE_STORAGE_UPDATE_PACKET = new Identifier("bundleinv", "bundle_storage_update");
 

--- a/src/main/java/com/wolfyscript/bundleinv/PlayerBundleStorage.java
+++ b/src/main/java/com/wolfyscript/bundleinv/PlayerBundleStorage.java
@@ -112,6 +112,10 @@ public class PlayerBundleStorage implements Clearable {
         stacks.clear();
     }
 
+    public int indexOf(ItemStack itemStack) {
+        return stacks.indexOf(itemStack);
+    }
+
     /**
      * Gets the ItemStack at the specified index in the storage.
      *

--- a/src/main/java/com/wolfyscript/bundleinv/PlayerBundleStorage.java
+++ b/src/main/java/com/wolfyscript/bundleinv/PlayerBundleStorage.java
@@ -112,6 +112,13 @@ public class PlayerBundleStorage implements Clearable {
         stacks.clear();
     }
 
+    /**
+     * Gets the ItemStack at the specified index in the storage.
+     *
+     * @param index The index of the ItemStack.
+     * @return The ItemStack at the index in the storage; otherwise {@link ItemStack#EMPTY} if item not available.
+     * @throws IndexOutOfBoundsException If the index is out of bounds.
+     */
     public ItemStack get(int index) {
         ItemStack itemStack = stacks.get(index);
         if (itemStack == null) {
@@ -165,7 +172,7 @@ public class PlayerBundleStorage implements Clearable {
             slot = (inventory.selectedSlot + i) % 9;
             if (inventory.main.get(slot).isEmpty()) return slot;
         }
-        // Find the best item to swap with the
+        // Find the best item to swap with
         int stackLoad = PlayerBundleStorage.getItemStackLoad(stack);
         int[] loadDiffs = new int[9];
         for (int i = 0; i < 9; ++i) {

--- a/src/main/java/com/wolfyscript/bundleinv/mixin/MixinMinecraftClient.java
+++ b/src/main/java/com/wolfyscript/bundleinv/mixin/MixinMinecraftClient.java
@@ -22,7 +22,7 @@ public class MixinMinecraftClient {
 
     @Shadow @Nullable public ClientPlayerEntity player;
 
-    @Inject(method = "doItemPick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;getSlotWithStack(Lnet/minecraft/item/ItemStack;)I", shift = At.Shift.AFTER, by = 2), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
+    @Inject(method = "doItemPick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;getSlotWithStack(Lnet/minecraft/item/ItemStack;)I", shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
     private void pickItemFromBundleInventory(CallbackInfo ci, boolean creative, BlockEntity blockEntity, ItemStack itemStack, HitResult.Type type, PlayerInventory playerInventory) {
         assert player != null;
         int itemSlot = playerInventory.getSlotWithStack(itemStack);
@@ -30,6 +30,7 @@ public class MixinMinecraftClient {
             if (itemSlot == -1) {
                 if (PlayerInventory.isValidHotbarIndex(itemSlot)) {
                     //TODO: Replenish stack!
+
 
                 } else {
                     PlayerBundleStorage bundleStorage = ((BundleStorageHolder)player.getInventory()).getBundleStorage();

--- a/src/main/java/com/wolfyscript/bundleinv/mixin/MixinMinecraftClient.java
+++ b/src/main/java/com/wolfyscript/bundleinv/mixin/MixinMinecraftClient.java
@@ -1,0 +1,46 @@
+package com.wolfyscript.bundleinv.mixin;
+
+import com.wolfyscript.bundleinv.BundleStorageHolder;
+import com.wolfyscript.bundleinv.PlayerBundleStorage;
+import com.wolfyscript.bundleinv.network.packets.C2SPickFromBundleStorage;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.hit.HitResult;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(MinecraftClient.class)
+public class MixinMinecraftClient {
+
+    @Shadow @Nullable public ClientPlayerEntity player;
+
+    @Inject(method = "doItemPick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;getSlotWithStack(Lnet/minecraft/item/ItemStack;)I", shift = At.Shift.AFTER, by = 2), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
+    private void pickItemFromBundleInventory(CallbackInfo ci, boolean creative, BlockEntity blockEntity, ItemStack itemStack, HitResult.Type type, PlayerInventory playerInventory) {
+        assert player != null;
+        int itemSlot = playerInventory.getSlotWithStack(itemStack);
+        if (!creative) {
+            if (itemSlot == -1) {
+                if (PlayerInventory.isValidHotbarIndex(itemSlot)) {
+                    //TODO: Replenish stack!
+
+                } else {
+                    PlayerBundleStorage bundleStorage = ((BundleStorageHolder)player.getInventory()).getBundleStorage();
+                    int bundleIndex = bundleStorage.getStacks().indexOf(itemStack);
+                    if (bundleIndex != -1) {
+                        C2SPickFromBundleStorage.sendToServer(itemStack);
+                        ci.cancel();
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/wolfyscript/bundleinv/mixin/MixinMinecraftClient.java
+++ b/src/main/java/com/wolfyscript/bundleinv/mixin/MixinMinecraftClient.java
@@ -8,7 +8,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.hit.HitResult;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -24,9 +23,6 @@ public abstract class MixinMinecraftClient {
     @Shadow
     @Nullable
     public ClientPlayerEntity player;
-
-    @Shadow
-    public abstract CrashReport addDetailsToCrashReport(CrashReport report);
 
     @Inject(method = "doItemPick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;getSlotWithStack(Lnet/minecraft/item/ItemStack;)I", shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
     private void pickItemFromBundleInventory(CallbackInfo ci, boolean creative, BlockEntity blockEntity, ItemStack itemStack, HitResult.Type type, PlayerInventory playerInventory) {

--- a/src/main/java/com/wolfyscript/bundleinv/network/packets/C2SPickFromBundleStorage.java
+++ b/src/main/java/com/wolfyscript/bundleinv/network/packets/C2SPickFromBundleStorage.java
@@ -8,12 +8,16 @@ import net.minecraft.network.PacketByteBuf;
 
 public class C2SPickFromBundleStorage {
 
-    public static void sendToServer(ItemStack stack) {
+    public static void sendToServer(Action action, int hotbarSlot, ItemStack stack) {
         PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeEnumConstant(action);
+        buf.writeInt(hotbarSlot);
         buf.writeItemStack(stack);
         ClientPlayNetworking.send(BundleInvConstants.C2S_PICK_FROM_BUNDLE_STORAGE, buf);
     }
 
-
+    public enum Action {
+        SWAP, REPLENISH
+    }
 
 }

--- a/src/main/java/com/wolfyscript/bundleinv/network/packets/C2SPickFromBundleStorage.java
+++ b/src/main/java/com/wolfyscript/bundleinv/network/packets/C2SPickFromBundleStorage.java
@@ -1,0 +1,19 @@
+package com.wolfyscript.bundleinv.network.packets;
+
+import com.wolfyscript.bundleinv.BundleInvConstants;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+
+public class C2SPickFromBundleStorage {
+
+    public static void sendToServer(ItemStack stack) {
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeItemStack(stack);
+        ClientPlayNetworking.send(BundleInvConstants.C2S_PICK_FROM_BUNDLE_STORAGE, buf);
+    }
+
+
+
+}

--- a/src/main/resources/bundleinv.mixins.json
+++ b/src/main/resources/bundleinv.mixins.json
@@ -10,7 +10,10 @@
   "client": [
     "AbstractInventoryScreenMixin",
     "InventoryScreenMixin",
+    "MixinMinecraftClient",
     "ScreenAccessor"
+  ],
+  "server": [
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Pick block is compatible with the Bundle Inventory now.
When middle-clicking on a block it looks for the item as follows:
* Is the item in the bundle inventory?
  -> Otherwise move to vanilla behaviour!
* Is the item already in the hotbar? Then move the selected slot to it
  * Can the stack be replenished with stacks from the bundle inventory?
* look for empty slot in the hotbar
* look for stack with smallest load for bundle inside the hotbar
  -> take the items with the smallest load and isn't enchanted and swap it.
* Otherwise swap selected slot